### PR TITLE
Fix HTTP referer sanitization

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -17,8 +17,8 @@ if (! defined('ABSPATH')) {
 function bookitfast_only_local($request = null)
 {
         $home = home_url();
-        if (isset($_SERVER['HTTP_REFERER'])) {
-                $ref = esc_url_raw($_SERVER['HTTP_REFERER']);
+       if (isset($_SERVER['HTTP_REFERER'])) {
+               $ref = esc_url_raw(wp_unslash($_SERVER['HTTP_REFERER']));
                 if (strpos($ref, $home) === 0) {
                         return true;
                 }


### PR DESCRIPTION
## Summary
- sanitize server HTTP_REFERER by unslashing it before calling `esc_url_raw`

## Testing
- `php -l includes/api.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68870dca0074832aadd2a19384debe27